### PR TITLE
added gecko driver for firefox.

### DIFF
--- a/asgi_redis/meta.yaml
+++ b/asgi_redis/meta.yaml
@@ -8,7 +8,7 @@ source:
   md5: 79c5f3d9cb6f0d2ed8618f72e498597e
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:
@@ -18,7 +18,7 @@ requirements:
   run:
     - python
     - six >=1.10.0
-    - redis >=2.10
+    - redis-py >=2.10
     - msgpack-python >=0.4.8
     - asgiref >=1.0.0
 

--- a/gecko-driver/bld.bat
+++ b/gecko-driver/bld.bat
@@ -1,0 +1,2 @@
+for /R "%SRC_DIR%" %%f in (*.exe) do copy %%f "%LIBRARY_BIN%"
+if errorlevel 1 exit 1

--- a/gecko-driver/build.sh
+++ b/gecko-driver/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+mkdir -vp ${PREFIX}/bin;
+
+cp -v geckodriver ${PREFIX}/bin/ || exit 1;
+chmod -v 755 ${PREFIX}/bin/geckodriver || exit 1;

--- a/gecko-driver/meta.yaml
+++ b/gecko-driver/meta.yaml
@@ -1,0 +1,20 @@
+package:
+  name: gecko-driver
+  version: 0.14.0
+
+source:
+  fn: geckodriver-v0.14.0-linux64.tar.gz                                                      # [linux64]
+  url: https://github.com/mozilla/geckodriver/releases/download/v0.14.0/geckodriver-v0.14.0-linux64.tar.gz      # [linux64]
+  fn: geckodriver-v0.14.0-win64.zip                                                          # [win]
+  url: https://github.com/mozilla/geckodriver/releases/download/v0.14.0/geckodriver-v0.14.0-win64.zip        # [win]
+
+build:
+  number: 0
+
+test:
+  commands:
+    - geckodriver --help
+
+about:
+  home: https://github.com/mozilla/geckodriver
+  license: New BSD License


### PR DESCRIPTION
This recipes copies the binaries directly. Having to build gecko driver would mean having rust toolchain as a build dependency and that's another recipe.

**This PR also fixes asgi_redis to use redis-py.**