### PR TITLE
Updated and fixed build for macOS

### DIFF
--- a/u3d/build.sh
+++ b/u3d/build.sh
@@ -4,9 +4,16 @@ BUILD_CONFIG=Release
 mkdir build
 cd build
 
-cmake .. -G "Unix Makefiles" \
-    -DCMAKE_BUILD_TYPE=$BUILD_CONFIG \
-    -DCMAKE_INSTALL_PREFIX=$PREFIX \
+if [ `uname` = 'Darwin' ]; then
+    export CXXFLAGS="${CXXFLAGS} -stdlib=libc++"
+fi
+
+cmake .. -G "Ninja" \
+    -DCMAKE_BUILD_TYPE=${BUILD_CONFIG} \
+    -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+    -DCMAKE_INSTALL_RPATH:PATH="${PREFIX}/lib" \
+    -DCMAKE_CXX_FLAGS="${CXXFLAGS}" \
+    ${MACOSX_DEPLOYMENT_TARGET:+-DCMAKE_OSX_DEPLOYMENT_TARGET='10.9'} \
     -DU3D_SHARED:BOOL=ON
 
-make install
+ninja install

--- a/u3d/meta.yaml
+++ b/u3d/meta.yaml
@@ -12,16 +12,16 @@ build:
 requirements:
   build:
     - python # [win]
-    - cmake >=3.6.0
-    - ninja >=1.7  # [unix]
-    - jpeg >=9b
-    - libpng >=1.6.27
-    - zlib >=1.2.8
+    - cmake 3.6.3
+    - ninja 1.7.1  # [unix]
+    - jpeg 9b
+    - libpng 1.6.27
+    - zlib 1.2.8
   run:
     - python # [win]
-    - jpeg >=9b
-    - libpng >=1.6.27
-    - zlib >=1.2.8
+    - jpeg 9b
+    - libpng 1.6.27
+    - zlib 1.2.8
 
 test:
   commands:

--- a/u3d/meta.yaml
+++ b/u3d/meta.yaml
@@ -8,24 +8,20 @@ source:
 
 build:
   number: 0
-  features:
-    - vc9  # [win and py27]
-    - vc10  # [win and py34]
-    - vc14  # [win and (py35 or py36)]
 
 requirements:
   build:
-    - python  # [win]
+    - python # [win]
     - cmake >=3.6.0
     - ninja >=1.7  # [unix]
-    - jpeg >=9b  # [win]
-    - libpng >=1.6.27  # [win]
-    - zlib >=1.2.8  # [win]
+    - jpeg >=9b
+    - libpng >=1.6.27
+    - zlib >=1.2.8
   run:
-    - python  # [win]
-    - jpeg >=9b  # [win]
-    - libpng >=1.6.27  # [win]
-    - zlib >=1.2.8  # [win]
+    - python # [win]
+    - jpeg >=9b
+    - libpng >=1.6.27
+    - zlib >=1.2.8
 
 test:
   commands:

--- a/u3d/meta.yaml
+++ b/u3d/meta.yaml
@@ -3,23 +3,23 @@ package:
     version: 0.3.1
 
 source:
-#    fn: u3d-v0.2.0.tar.gz
-#    url: https://github.com/ClinicalGraphics/u3d/archive/0.2.0.tar.gz
-    path: ../../u3d/
+    fn: 0.3.1.tar.gz
+    url: https://github.com/ClinicalGraphics/u3d/archive/0.3.1.tar.gz
 
 build:
-    number: 0
+    number: 1
 
 requirements:
     build:
-        - cmake
-        - jpeg
-        - libpng
-        - zlib
+        - cmake >=3.6.0
+        - ninja >=1.7
+        - jpeg >=9b
+        - libpng >=1.6.27
+        - zlib >=1.2.8
     run:
-        - jpeg
-        - libpng
-        - zlib
+        - jpeg >=9b
+        - libpng >=1.6.27
+        - zlib >=1.2.8
 
 test:
     commands:

--- a/u3d/meta.yaml
+++ b/u3d/meta.yaml
@@ -1,32 +1,38 @@
 package:
-    name: u3d
-    version: 0.3.2
+  name: u3d
+  version: 0.3.2
 
 source:
-    fn: 0.3.2.tar.gz
-    url: https://github.com/ClinicalGraphics/u3d/archive/0.3.2.tar.gz
+  fn: 0.3.2.tar.gz
+  url: https://github.com/ClinicalGraphics/u3d/archive/0.3.2.tar.gz
 
 build:
-    number: 0
+  number: 0
+  features:
+    - vc9  # [win and py27]
+    - vc10  # [win and py34]
+    - vc14  # [win and (py35 or py36)]
 
 requirements:
-    build:
-        - cmake >=3.6.0
-        - ninja >=1.7
-        - jpeg >=9b
-        - libpng >=1.6.27
-        - zlib >=1.2.8
-    run:
-        - jpeg >=9b
-        - libpng >=1.6.27
-        - zlib >=1.2.8
+  build:
+    - python  # [win]
+    - cmake >=3.6.0
+    - ninja >=1.7  # [unix]
+    - jpeg >=9b  # [win]
+    - libpng >=1.6.27  # [win]
+    - zlib >=1.2.8  # [win]
+  run:
+    - python  # [win]
+    - jpeg >=9b  # [win]
+    - libpng >=1.6.27  # [win]
+    - zlib >=1.2.8  # [win]
 
 test:
-    commands:
-        - IDTFGen || true
-        - IDTFConverter -input test.idtf -output test.u3d -debuglevel 0
+  commands:
+    - IDTFGen || true
+    - IDTFConverter -input test.idtf -output test.u3d -debuglevel 0
 
 about:
-    home: https://github.com/ClinicalGraphics/u3d
-    license: Apache-2.0
-    summary: Universal 3D Sample Software
+  home: https://github.com/ClinicalGraphics/u3d
+  license: Apache-2.0
+  summary: Universal 3D Sample Software

--- a/u3d/meta.yaml
+++ b/u3d/meta.yaml
@@ -12,8 +12,8 @@ build:
 requirements:
   build:
     - python # [win]
-    - cmake 3.6.3
-    - ninja 1.7.1  # [unix]
+    - cmake
+    - ninja  # [unix]
     - jpeg 9b
     - libpng 1.6.27
     - zlib 1.2.8

--- a/u3d/meta.yaml
+++ b/u3d/meta.yaml
@@ -1,13 +1,13 @@
 package:
     name: u3d
-    version: 0.3.1
+    version: 0.3.2
 
 source:
-    fn: 0.3.1.tar.gz
-    url: https://github.com/ClinicalGraphics/u3d/archive/0.3.1.tar.gz
+    fn: 0.3.2.tar.gz
+    url: https://github.com/ClinicalGraphics/u3d/archive/0.3.2.tar.gz
 
 build:
-    number: 1
+    number: 0
 
 requirements:
     build:

--- a/vtku3dexporter/bld.bat
+++ b/vtku3dexporter/bld.bat
@@ -1,24 +1,6 @@
 set BUILD_CONFIG=Release
+set PYTHON_LIBRARY=%PREFIX%\libs\python%PY_VER:~0,1%%PY_VER:~2,1%.lib
 
-REM tell cmake where Python is
-set PYTHON_LIBRARY=%CENV%\libs\python%PY_VER:~0,1%%PY_VER:~2,1%.lib
-
-REM Build u3d First
-mkdir build
-cd build
-
-cmake .. -G "NMake Makefiles" ^
-    -Wno-dev ^
-    -DCMAKE_BUILD_TYPE=%BUILD_CONFIG% ^
-    -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^
-    -DU3D_SHARED:BOOL=ON
-if errorlevel 1 exit 1
-
-nmake install
-if errorlevel 1 exit 1
-
-REM Then build vkt to u3d exporter
-cd ..
 cd Samples\SampleCode
 
 cmake . -G "NMake Makefiles" ^

--- a/vtku3dexporter/build.sh
+++ b/vtku3dexporter/build.sh
@@ -1,48 +1,27 @@
 #!/usr/bin/env bash
 BUILD_CONFIG=Release
 
-# Build u3d First
+# use globs to take into account various possible suffixes: m, u, d
+PYTHON_LIBRARY=`ls -d ${PREFIX}/lib/libpython* | head -n 1`
+PYTHON_INCLUDE=`ls -d ${PREFIX}/include/python* | head -n 1`
+
+if [ `uname` = 'Darwin' ]; then
+    export CXXFLAGS="${CXXFLAGS} -stdlib=libc++"
+fi
+
 mkdir build
 cd build
 
-cmake .. -G "Unix Makefiles" \
-    -DCMAKE_BUILD_TYPE=$BUILD_CONFIG \
-    -DCMAKE_INSTALL_PREFIX=$PREFIX \
-    -DU3D_SHARED:BOOL=ON
-
-make install
-
-# Then build vkt to u3d exporter
-cd ..
-cd Samples/SampleCode
-
-# sometimes python is suffixed, these are quick fixes
-# in a future PR we should probably switch to cmake find python scripting
-PYTHON_INCLUDE="${PREFIX}/include/python${PY_VER}"
-if [ ! -d $PYTHON_INCLUDE ]; then
-    PYTHON_INCLUDE="${PREFIX}/include/python${PY_VER}m"
-fi
-
-PYTHON_LIBRARY_EXT="so"
-if [ `uname` = "Darwin" ] ; then
-    PYTHON_LIBRARY_EXT="dylib"
-fi
-
-PYTHON_LIBRARY="${PREFIX}/lib/libpython${PY_VER}.${PYTHON_LIBRARY_EXT}"
-if [ ! -f $PYTHON_LIBRARY ]; then
-    PYTHON_LIBRARY="${PREFIX}/lib/libpython${PY_VER}m.${PYTHON_LIBRARY_EXT}"
-fi
-
-# end of quick fixes
-export CXXFLAGS="$CXXFLAGS -fPIC"
-
-cmake . -G "Unix Makefiles" \
-    -DCMAKE_BUILD_TYPE=$BUILD_CONFIG \
+# Compile the code from the Samples/SampleCode directory
+cmake ../Samples/SampleCode -G "Ninja" \
+    -DCMAKE_BUILD_TYPE=${BUILD_CONFIG} \
     -DCMAKE_INSTALL_PREFIX:PATH="${PREFIX}" \
     -DCMAKE_INSTALL_RPATH:PATH="${PREFIX}/lib" \
+    -DCMAKE_CXX_FLAGS="${CXXFLAGS}" \
+    ${MACOSX_DEPLOYMENT_TARGET:+-DCMAKE_OSX_DEPLOYMENT_TARGET='10.9'} \
     -DWRAP_PYTHON:BOOL=ON \
     -DINSTALL_PYTHON_MODULE_DIR:PATH="${SP_DIR}" \
-    -DPYTHON_INCLUDE_DIR:PATH=$PYTHON_INCLUDE \
-    -DPYTHON_LIBRARY:FILEPATH=$PYTHON_LIBRARY
+    -DPYTHON_INCLUDE_DIR:PATH=${PYTHON_INCLUDE} \
+    -DPYTHON_LIBRARY:FILEPATH=${PYTHON_LIBRARY}
 
-make install
+ninja install

--- a/vtku3dexporter/meta.yaml
+++ b/vtku3dexporter/meta.yaml
@@ -15,11 +15,11 @@ requirements:
     - cmake >=3.6.0
     - ninja >=1.7  # [unix]
     - u3d 0.3.2
-    - vtk >=7.1.0
+    - vtk 7.1.0
   run:
     - python
     - u3d 0.3.2
-    - vtk >=7.1.0
+    - vtk 7.1.0
 
 test:
   imports:

--- a/vtku3dexporter/meta.yaml
+++ b/vtku3dexporter/meta.yaml
@@ -1,23 +1,24 @@
 package:
   name: vtku3dexporter
-  version: 0.3.1
+  version: 0.3.2
 
 source:
-  fn: 0.3.1.tar.gz
-  url: https://github.com/ClinicalGraphics/u3d/archive/0.3.1.tar.gz
+  fn: 0.3.2.tar.gz
+  url: https://github.com/ClinicalGraphics/u3d/archive/0.3.2.tar.gz
 
 build:
-  number: 4
+  number: 0
 
 requirements:
   build:
     - python
+    - u3d 0.3.2
     - cmake >=3.6.0
+    - ninja >=1.7
     - vtk >=7.1.0
-    - jpeg >=9b  # [win]
-    - libpng >=1.6.27  # [win]
   run:
     - python
+    - u3d 0.3.2
     - vtk >=7.1.0
 
 test:

--- a/vtku3dexporter/meta.yaml
+++ b/vtku3dexporter/meta.yaml
@@ -12,9 +12,9 @@ build:
 requirements:
   build:
     - python
-    - u3d 0.3.2
     - cmake >=3.6.0
-    - ninja >=1.7
+    - ninja >=1.7  # [unix]
+    - u3d 0.3.2
     - vtk >=7.1.0
   run:
     - python


### PR DESCRIPTION
This PR splits the build of U3D and vtkU3DExporter again into two packages.
Should also work on Linux now, though that still needs to be confirmed officially.