### PR TITLE
Bumping flexx to dev5

### DIFF
--- a/flexx/meta.yaml
+++ b/flexx/meta.yaml
@@ -1,12 +1,12 @@
-{% set version = "0.4.1.dev1" %}
+{% set version = "0.4.1.dev5" %}
 
 package:
   name: flexx
   version: {{ version }}
 
 source:
-  git_url: https://github.com/zoofIO/flexx.git
-  git_rev: e966c8d3a343737ff8189519b4a8cdcb2270b8e9
+  git_url: https://github.com/ivoflipse/flexx.git
+  git_rev: 13bcac5eaaee43e3d1a9a791b148bfcf04a1a89a
 
 build:
   script: python setup.py install --single-version-externally-managed --record=record.txt


### PR DESCRIPTION
Because Almar is on vacation, we can't fix the problem in the flexx repo. Therefore I'm pointing it to my commit that should fix the problem for now. We can make a new release once Almar gets back.